### PR TITLE
Uso de const y let

### DIFF
--- a/buildingadminback/routes/index.js
+++ b/buildingadminback/routes/index.js
@@ -1,14 +1,14 @@
-var express = require('express');
-var router = express.Router();
-var mongodb =require('mongodb');
+const express = require('express');
+const router = express.Router();
+const mongodb =require('mongodb');
 
-var url ="mongodb://165.227.187.208:4536/tenants";
+const url ="mongodb://165.227.187.208:4536/tenants";
 
 function getTenants(callback){
   mongodb.connect(url, (err,db) => {
     if (err) throw err;
 
-    var tenants =  db.collection("tenants");
+    let tenants =  db.collection("tenants");
     tenants.find({}).toArray((err2, tenants)=>{
       if (err2) throw err2;
 


### PR DESCRIPTION
Cuando usas la versión ES6 de JavaScript puedes hacer uso de const y let en lugar de var, esto hace que el código sea más claro.